### PR TITLE
Implementing the NOTESDIR env variable usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Store your thoughts on all sorts of subjects and easily read them on the
 commandline. I use it for CLI commands I don't use very often and keep
 forgetting.
 
-Currently it expects a `~/dotfiles/notes/` directory to store all the notes.
+Currently it expects a `~/dotfiles/notes/` directory to store all the notes
+but you can override this by setting the `$NOTESDIR` variable.
 These are just simple textfiles for easy editting and portability.
 
 You can use # comments to explain the command, these will get colorized when
@@ -33,3 +34,7 @@ a desired location.
 
 Editting and creating new notes uses $EDITOR or vi if that is not set.
 
+
+## Testing
+
+To run the tests simply use the `go test` command.

--- a/notes.go
+++ b/notes.go
@@ -73,8 +73,12 @@ func getEditor() string {
 }
 
 func getHomeDir() string {
-	home := os.Getenv("HOME")
-	return fmt.Sprintf("%v/dotfiles/notes/", home)
+	notesdir := os.Getenv("NOTESDIR")
+	if notesdir != "" {
+		return notesdir
+	} else {
+		return fmt.Sprintf("%v/dotfiles/notes/", os.Getenv("HOME"))
+	}
 }
 
 func main() {
@@ -117,5 +121,4 @@ func main() {
 		},
 	}
 	app.Run(os.Args)
-
 }

--- a/notes_test.go
+++ b/notes_test.go
@@ -31,3 +31,13 @@ func TestGetHomeDir(t *testing.T) {
 	outcome := getHomeDir()
 	assert.Equal(t, expected, outcome)
 }
+
+func TestGetHomeDirWithEnvVariable(t *testing.T) {
+	err := os.Setenv("NOTESDIR", "/some/other/path/")
+	if err != nil {
+		t.Fatalf("Setenv failed")
+	}
+	expected := "/some/other/path/"
+	outcome := getHomeDir()
+	assert.Equal(t, expected, outcome)
+}


### PR DESCRIPTION
Before we were statically using the $HOME/dotfiles/notes directory as the
repository for the notes.  This commit introduces a change to allow users
to dynamically set the location of the notes by setting the $NOTESDIR
env variable.
